### PR TITLE
Add audio, volume controls and store

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
+import { AudioProvider } from "@/components/audio-provider"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
@@ -16,7 +17,9 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AudioProvider>{children}</AudioProvider>
+      </body>
     </html>
   );
 }

--- a/components/action-buttons.tsx
+++ b/components/action-buttons.tsx
@@ -12,6 +12,7 @@ interface ActionButtonsProps {
   onMove: (direction: "left" | "right" | "up" | "down") => void;
   onBack: () => void;
   onStartGame: () => void;
+  onToggleVolume: () => void;
   isSleeping: boolean;
   isStarting: boolean;
   inMenu: boolean;
@@ -25,6 +26,7 @@ export default function ActionButtons({
   onStart,
   onMove,
   onBack,
+  onToggleVolume,
   isSleeping,
   isStarting,
   inMenu,
@@ -135,19 +137,27 @@ export default function ActionButtons({
         SLEEP
       </button>
 
-      {/* Start y Reset */}
-      <div className="flex gap-6 mt-3">
+      {/* Start, Vol y Reset */}
+      <div className="flex gap-4 mt-3">
         <button
           onClick={() => handleAction("start", onStart)}
-          className="px-5 py-1 rounded-lg bg-gray-400 shadow-[inset_0_1px_2px_rgba(255,255,255,0.5),0_2px_0px_rgba(0,0,0,0.5)] 
+          className="px-5 py-1 rounded-lg bg-gray-400 shadow-[inset_0_1px_2px_rgba(255,255,255,0.5),0_2px_0px_rgba(0,0,0,0.5)]
                      hover:brightness-110 text-black text-xs font-bold pixel-font"
         >
           START
         </button>
 
         <button
+          onClick={() => handleAction("vol", onToggleVolume)}
+          className="px-5 py-1 rounded-lg bg-gray-400 shadow-[inset_0_1px_2px_rgba(255,255,255,0.5),0_2px_0px_rgba(0,0,0,0.5)]
+                     hover:brightness-110 text-black text-xs font-bold pixel-font"
+        >
+          VOL
+        </button>
+
+        <button
           onClick={onReset}
-          className="px-5 py-1 rounded-lg bg-gray-400 shadow-[inset_0_1px_2px_rgba(255,255,255,0.5),0_2px_0px_rgba(0,0,0,0.5)] 
+          className="px-5 py-1 rounded-lg bg-gray-400 shadow-[inset_0_1px_2px_rgba(255,255,255,0.5),0_2px_0px_rgba(0,0,0,0.5)]
                      hover:brightness-110 text-black text-xs font-bold pixel-font"
         >
           Reset

--- a/components/audio-provider.tsx
+++ b/components/audio-provider.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { createContext, useContext, useState, useRef, useEffect } from "react";
+
+interface AudioContextValue {
+  generalVolume: number;
+  effectsVolume: number;
+  musicVolume: number;
+  setGeneralVolume: (v: number) => void;
+  setEffectsVolume: (v: number) => void;
+  setMusicVolume: (v: number) => void;
+  playEffect: (url: string) => void;
+  playMusic: (url: string) => void;
+  stopMusic: () => void;
+}
+
+const AudioCtx = createContext<AudioContextValue | undefined>(undefined);
+
+export const useAudio = () => {
+  const ctx = useContext(AudioCtx);
+  if (!ctx) throw new Error("useAudio must be inside AudioProvider");
+  return ctx;
+};
+
+export function AudioProvider({ children }: { children: React.ReactNode }) {
+  const [generalVolume, setGeneralVolume] = useState(1);
+  const [effectsVolume, setEffectsVolume] = useState(1);
+  const [musicVolume, setMusicVolume] = useState(1);
+  const musicRef = useRef<HTMLAudioElement | null>(null);
+
+  const playEffect = (url: string) => {
+    if (!url) return;
+    const audio = new Audio(url);
+    audio.volume = generalVolume * effectsVolume;
+    audio.play();
+  };
+
+  const playMusic = (url: string) => {
+    if (!url) return;
+    if (musicRef.current) {
+      musicRef.current.pause();
+    }
+    musicRef.current = new Audio(url);
+    musicRef.current.loop = true;
+    musicRef.current.volume = generalVolume * musicVolume;
+    musicRef.current.play();
+  };
+
+  const stopMusic = () => {
+    if (musicRef.current) {
+      musicRef.current.pause();
+      musicRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    if (musicRef.current) {
+      musicRef.current.volume = generalVolume * musicVolume;
+    }
+  }, [generalVolume, musicVolume]);
+
+  const value: AudioContextValue = {
+    generalVolume,
+    effectsVolume,
+    musicVolume,
+    setGeneralVolume,
+    setEffectsVolume,
+    setMusicVolume,
+    playEffect,
+    playMusic,
+    stopMusic,
+  };
+
+  return <AudioCtx.Provider value={value}>{children}</AudioCtx.Provider>;
+}

--- a/components/store-modal.tsx
+++ b/components/store-modal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React from "react";
+import { NoaState } from "./noa-tamagotchi";
+
+interface Item {
+  id: string;
+  name: string;
+  price: number;
+  apply: (s: NoaState) => NoaState;
+}
+
+const items: Item[] = [
+  {
+    id: "food",
+    name: "🍖 Comida",
+    price: 50,
+    apply: (s) => ({ ...s, hunger: Math.min(s.hunger + 20, 100) }),
+  },
+  {
+    id: "toy",
+    name: "🎁 Juguete",
+    price: 50,
+    apply: (s) => ({ ...s, happiness: Math.min(s.happiness + 20, 100) }),
+  },
+  {
+    id: "pillow",
+    name: "💤 Almohada",
+    price: 50,
+    apply: (s) => ({ ...s, energy: Math.min(s.energy + 20, 100) }),
+  },
+];
+
+export default function StoreModal({
+  points,
+  onClose,
+  onPurchase,
+}: {
+  points: number;
+  onClose: () => void;
+  onPurchase: (cost: number, apply: (s: NoaState) => NoaState) => void;
+}) {
+  return (
+    <div className="absolute inset-0 bg-black/60 flex flex-col items-center justify-center text-white pixel-font p-4" style={{ backdropFilter: "blur(2px)" }}>
+      <h2 className="text-lg mb-2">Tienda</h2>
+      <p className="text-xs mb-2">Puntos: {points}</p>
+      <div className="flex flex-col gap-2 mb-2 w-40">
+        {items.map((it) => (
+          <button
+            key={it.id}
+            onClick={() => onPurchase(it.price, it.apply)}
+            className="bg-gray-700 hover:bg-gray-600 px-2 py-1 text-xs rounded"
+          >
+            {it.name} - {it.price}
+          </button>
+        ))}
+      </div>
+      <button onClick={onClose} className="bg-gray-700 px-3 py-1 text-xs rounded">
+        Cerrar
+      </button>
+    </div>
+  );
+}

--- a/components/volume-menu.tsx
+++ b/components/volume-menu.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+import { useAudio } from "./audio-provider";
+
+export default function VolumeMenu({ onClose }: { onClose: () => void }) {
+  const {
+    generalVolume,
+    effectsVolume,
+    musicVolume,
+    setGeneralVolume,
+    setEffectsVolume,
+    setMusicVolume,
+  } = useAudio();
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 bg-black/80 text-white pixel-font p-2 z-30">
+      <h2 className="text-center text-sm mb-2">Volumen</h2>
+      <div className="flex flex-col gap-2 text-xs">
+        <label className="flex items-center gap-2">
+          General
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.1"
+            value={generalVolume}
+            onChange={(e) => setGeneralVolume(parseFloat(e.target.value))}
+            className="flex-1"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Efectos
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.1"
+            value={effectsVolume}
+            onChange={(e) => setEffectsVolume(parseFloat(e.target.value))}
+            className="flex-1"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Música
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.1"
+            value={musicVolume}
+            onChange={(e) => setMusicVolume(parseFloat(e.target.value))}
+            className="flex-1"
+          />
+        </label>
+        <button
+          onClick={onClose}
+          className="mt-2 bg-gray-700 rounded px-2 py-1 text-xs"
+        >
+          Cerrar
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap app with `AudioProvider`
- add global audio context and playback helpers
- implement `VolumeMenu` with sliders
- update action buttons to toggle volume menu
- create simple store modal to spend points for stat boosts
- track and save points in tamagotchi and display them
- add win conditions and scoring callbacks in minigames
- play sounds for menu interactions and game results

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9d666a4c83259b2178ec21137232