### PR TITLE
Remove shop navigation footer

### DIFF
--- a/components/shopModal.tsx
+++ b/components/shopModal.tsx
@@ -123,14 +123,7 @@ export default function ShopModal({
               </div>
             )}
 
-            <div className="mt-4 text-center flex-shrink-0 space-y-1">
-              {confirming ? null : (
-                <p className="text-xs text-blue-200">
-                  {selectedItem.id === "exit" ? "A = Salir" : "A = Comprar"}
-                </p>
-              )}
-              <p className="text-xs text-blue-200">B = Volver</p>
-          </div>
+            {/* Navigation instructions removed */}
         </div>
       </div>
         </div>


### PR DESCRIPTION
## Summary
- remove footer instructions from shopModal so the shop screen no longer displays "A = ... / B = Volver"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798afd51c48325980053c5c860ffd8