### PR TITLE
Allow solid color backgrounds

### DIFF
--- a/components/noa-tamagotchi.tsx
+++ b/components/noa-tamagotchi.tsx
@@ -267,6 +267,10 @@ export default function NoaTamagotchi() {
       setInventory((inv) => ({ ...inv, plant: true }));
     } else if (id === "teddy") {
       setInventory((inv) => ({ ...inv, teddy: true }));
+    } else if (item.color) {
+      setBackgroundImage(item.color);
+    } else if (item.image) {
+      setBackgroundImage(item.image);
     }
     setShopError(null);
     setShopConfirm(null);
@@ -543,11 +547,15 @@ export default function NoaTamagotchi() {
       {/* -------------------- PANTALLA -------------------- */}
       <div
         className="gameboy-screen relative overflow-hidden"
-        style={{
-          backgroundImage: `url(${backgroundImage})`,
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-        }}
+        style={
+          backgroundImage.startsWith("#")
+            ? { backgroundColor: backgroundImage }
+            : {
+                backgroundImage: `url(${backgroundImage})`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }
+        }
       >
         {/* === Press Start === */}
         {screen === "start" && !noaDead && (

--- a/components/shopModal.tsx
+++ b/components/shopModal.tsx
@@ -12,11 +12,21 @@ export type ShopModalProps = {
   error: string | null;
 };
 
-export const shopItems = [
+export type ShopItem = {
+  id: string;
+  name: string;
+  price: number;
+  category: string;
+  image?: string;
+  color?: string;
+};
+
+export const shopItems: readonly ShopItem[] = [
   { id: "food", name: "🍗 Comida deliciosa", price: 10, category: "food" },
   { id: "plant", name: "🌱 Planta decorativa", price: 15, category: "toys" },
   { id: "teddy", name: "🧸 Peluche suave", price: 20, category: "toys" },
   { id: "bed", name: "🛏️ Cama nueva cómoda", price: 30, category: "themes" },
+  { id: "blue-bg", name: "🔵 Fondo azul", price: 25, category: "themes", color: "#3b82f6" },
 ] as const;
 
 export default function ShopModal({
@@ -95,7 +105,7 @@ export default function ShopModal({
                       );
                     }
                     elements.push(
-                      <div
+                    <div
                         key={item.id}
                         data-index={index}
                         className={`min-w-[90px] flex-shrink-0 flex flex-col items-center px-2 py-2 bg-[#113] border border-blue-400 rounded transition-all duration-150 text-center ${
@@ -104,7 +114,20 @@ export default function ShopModal({
                             : ""
                         }`}
                       >
-                        <span className="text-xs mb-1">{item.name}</span>
+                        {item.image && (
+                          <img
+                            src={item.image}
+                            alt={item.name}
+                            className="w-6 h-6 mb-1 object-cover"
+                          />
+                        )}
+                        {item.color && (
+                          <div
+                            className="w-6 h-6 mb-1 rounded"
+                            style={{ backgroundColor: item.color }}
+                          />
+                        )}
+                        <span className="text-xs mb-1 text-center">{item.name}</span>
                         {item.id !== "exit" && (
                           <span className="text-[10px]">{item.price} 🪙</span>
                         )}


### PR DESCRIPTION
## Summary
- let `shopItems` specify `color` or `image`
- display color square previews in the shop
- set the game screen background to that color when buying

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68798b2e41248325b9f53dfe1597c46f