### PR TITLE
Persist background theme across sessions

### DIFF
--- a/components/noa-tamagotchi.tsx
+++ b/components/noa-tamagotchi.tsx
@@ -89,6 +89,8 @@ export default function NoaTamagotchi() {
     if (stored) setCoinsSpent(parseInt(stored, 10));
     const inv = localStorage.getItem("inventory");
     if (inv) setInventory(JSON.parse(inv));
+    const bg = localStorage.getItem("backgroundImage");
+    if (bg) setBackgroundImage(bg);
   }, []);
 
   const getTotalScore = useCallback(() => {
@@ -137,6 +139,10 @@ export default function NoaTamagotchi() {
   useEffect(() => {
     localStorage.setItem("inventory", JSON.stringify(inventory));
   }, [inventory]);
+
+  useEffect(() => {
+    localStorage.setItem("backgroundImage", backgroundImage);
+  }, [backgroundImage]);
 
   // 3) Decaimiento de stats cada minuto
   useEffect(() => {
@@ -267,6 +273,10 @@ export default function NoaTamagotchi() {
       setInventory((inv) => ({ ...inv, plant: true }));
     } else if (id === "teddy") {
       setInventory((inv) => ({ ...inv, teddy: true }));
+    } else if (id === "bed") {
+      const newBg = "/images/back-grounds/azul-patitas.png";
+      setBackgroundImage(newBg);
+      localStorage.setItem("backgroundImage", newBg);
     }
     setShopError(null);
     setShopConfirm(null);


### PR DESCRIPTION
## Summary
- load background image from localStorage on mount
- persist backgroundImage state to localStorage
- update backgroundImage when purchasing the bed theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798b2ff5448325834b65f9f8c34b8a