### PR TITLE
Update scoreboard ranking and add cleanup script

### DIFF
--- a/components/mini-game-catch.tsx
+++ b/components/mini-game-catch.tsx
@@ -324,7 +324,7 @@ export default function MiniGameCatch({ onExit, moveCommand, startCommand, onGam
 
       {gameOver && (
         viewingRecords ? (
-          <ScoreBoard gameType="catch" onClose={onExit} />
+          <ScoreBoard gameType="catch" onClose={onExit} embedded />
         ) : (
           <div className="absolute inset-0 bg-black/60 flex flex-col items-center justify-center text-white pixel-font">
             <img src="/images/noa-llorando.png" alt="Noa triste" className="w-[62px] h-[62px] mb-1" />

--- a/components/mini-game-space.tsx
+++ b/components/mini-game-space.tsx
@@ -231,7 +231,7 @@ export default function MiniGameSpace({ onExit, moveCommand, startCommand, onGam
       )}
       {gameOver && (
         viewingRecords ? (
-          <ScoreBoard onClose={onExit} />
+          <ScoreBoard onClose={onExit} gameType="space" embedded />
         ) : (
           <div className="absolute inset-0 bg-black/80 flex flex-col items-center justify-center text-white pixel-font">
             <Image src="/images/space-game/explocion.png" alt="Boom" width={48} height={48} className="pixel-art mb-2" />

--- a/components/mini-game-space.tsx
+++ b/components/mini-game-space.tsx
@@ -43,12 +43,14 @@ export default function MiniGameSpace({ onExit, moveCommand, startCommand, onGam
   const spawnIntervalRef = useRef(INITIAL_SPAWN_INTERVAL);
   const spawnTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const saveSpaceGameScore = async (score: number) => {
+  const saveSpaceGameScore = async (score: number, duration: string) => {
     try {
       const { data, error } = await supabase.from("game_scores").insert([
         {
           score: score,
           game_type: "space",
+          date: new Date().toLocaleDateString("es-ES"),
+          time: duration,
           created_at: new Date().toISOString(),
         },
       ]);
@@ -66,7 +68,7 @@ export default function MiniGameSpace({ onExit, moveCommand, startCommand, onGam
     const s = Math.floor((elapsedMs % 60000) / 1000);
     const duration = `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
     const score = Math.floor(elapsedMs / 1000);
-    saveSpaceGameScore(score);
+    saveSpaceGameScore(score, duration);
     onGameEnd?.(score, true);
   }, [gameOver, elapsed, onGameEnd]);
 

--- a/components/score-board.tsx
+++ b/components/score-board.tsx
@@ -15,9 +15,10 @@ interface ScoreBoardProps {
   onClose: () => void;
   gameType?: string; // ← filtro opcional por tipo de juego
   onReset?: () => void; // callback opcional para reset externo
+  embedded?: boolean; // si true se muestra dentro de la pantalla del juego
 }
 
-export default function ScoreBoard({ onClose, gameType, onReset }: ScoreBoardProps) {
+export default function ScoreBoard({ onClose, gameType, onReset, embedded = false }: ScoreBoardProps) {
   const [records, setRecords] = useState<RecordEntry[]>([]);
   const [confirm, setConfirm] = useState(false);
 
@@ -49,17 +50,22 @@ export default function ScoreBoard({ onClose, gameType, onReset }: ScoreBoardPro
 
     fetchScores();
 
-    const channel = supabase
-      .channel("scores")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "game_scores" },
-        fetchScores,
-      )
-      .subscribe();
+    let channel: any = null;
+    if (typeof (supabase as any).channel === "function") {
+      channel = supabase
+        .channel("scores")
+        .on(
+          "postgres_changes",
+          { event: "*", schema: "public", table: "game_scores" },
+          fetchScores,
+        )
+        .subscribe();
+    }
 
     return () => {
-      supabase.removeChannel(channel);
+      if (channel) {
+        (supabase as any).removeChannel(channel);
+      }
     };
   }, [gameType]);
 
@@ -86,7 +92,11 @@ export default function ScoreBoard({ onClose, gameType, onReset }: ScoreBoardPro
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+    <div
+      className={
+        `${embedded ? "absolute" : "fixed"} inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50`
+      }
+    >
       <div className="bg-gray-800 text-white p-4 rounded-lg shadow-lg max-h-[80vh] overflow-y-auto w-[90%] max-w-md">
         <h2 className="text-xl font-bold mb-2">
           {gameType ? `Historial de "${gameType}"` : "Historial de puntuaciones"}
@@ -96,22 +106,29 @@ export default function ScoreBoard({ onClose, gameType, onReset }: ScoreBoardPro
           <p className="text-sm text-center text-gray-300">No hay puntuaciones registradas.</p>
         ) : (
           <>
-            <div className="grid grid-cols-5 gap-2 text-sm font-semibold mb-1 border-b border-gray-600 pb-1">
+            <div
+              className={`grid gap-2 text-sm font-semibold mb-1 border-b border-gray-600 pb-1 ${
+                gameType ? "grid-cols-4" : "grid-cols-5"
+              }`}
+            >
               <span>Pos.</span>
-              <span>Juego</span>
+              {!gameType && <span>Juego</span>}
               <span>Fecha</span>
               <span>Hora</span>
               <span>Puntos</span>
             </div>
             {records.map((r, idx) => (
-              <div key={r.id} className="grid grid-cols-5 gap-2 text-sm items-center">
+              <div
+                key={r.id}
+                className={`grid gap-2 text-sm items-center ${gameType ? "grid-cols-4" : "grid-cols-5"}`}
+              >
                 <span className="flex items-center">
                   {idx + 1}°
                   {idx === 0 && <span className="ml-1">👑</span>}
                   {idx === 1 && <span className="ml-1">🥈</span>}
                   {idx === 2 && <span className="ml-1">🥉</span>}
                 </span>
-                <span className="capitalize">{r.gameType}</span>
+                {!gameType && <span className="capitalize">{r.gameType}</span>}
                 <span>{r.date}</span>
                 <span>{r.time}</span>
                 <span>{r.score}</span>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "cleanup": "node scripts/cleanup.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -1,0 +1,62 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Supabase credentials missing');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: { persistSession: false },
+});
+
+function timeToSec(t) {
+  if (!t) return 0;
+  const [m, s] = t.split(':').map(Number);
+  return (m || 0) * 60 + (s || 0);
+}
+
+async function cleanupGameScores() {
+  const { data: allTypes, error } = await supabase.from('game_scores').select('game_type');
+  if (error) throw error;
+  const types = [...new Set((allTypes || []).map(t => t.game_type))];
+  for (const type of types) {
+    const { data: all } = await supabase
+      .from('game_scores')
+      .select('id,time')
+      .eq('game_type', type);
+    const sorted = (all || [])
+      .sort((a, b) => timeToSec(b.time) - timeToSec(a.time))
+      .slice(0, 10);
+    const keepIds = sorted.map(r => r.id);
+    const idsToDelete = (all || []).map(r => r.id).filter(id => !keepIds.includes(id));
+    if (idsToDelete.length) {
+      await supabase.from('game_scores').delete().in('id', idsToDelete);
+    }
+  }
+}
+
+async function cleanupNoaStats() {
+  const { data: all } = await supabase
+    .from('noa_stats')
+    .select('id')
+    .order('updated_at', { ascending: false });
+  const keep = (all || []).slice(0, 10).map(r => r.id);
+  const toDelete = (all || []).map(r => r.id).filter(id => !keep.includes(id));
+  if (toDelete.length) {
+    await supabase.from('noa_stats').delete().in('id', toDelete);
+  }
+}
+
+(async () => {
+  try {
+    await cleanupGameScores();
+    await cleanupNoaStats();
+    console.log('Cleanup completed');
+  } catch (e) {
+    console.error('Cleanup error:', e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- update scoreboard to order by time and refresh on DB changes
- store duration for space minigame
- add cleanup script to keep top 10 scores and stats

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6885da5d54fc83258bfc10037012c38c