### PR TITLE
Persist state in Supabase and add cleanup cron

### DIFF
--- a/components/mini-game-space.tsx
+++ b/components/mini-game-space.tsx
@@ -45,7 +45,8 @@ export default function MiniGameSpace({ onExit, moveCommand, startCommand, onGam
 
   const saveSpaceGameScore = async (score: number, duration: string) => {
     try {
-      const { data, error } = await supabase.from("game_scores").insert([
+      console.log("[space.saveScore] inserting", { score, duration });
+      const { error } = await supabase.from("game_scores").insert([
         {
           score: score,
           game_type: "space",
@@ -55,9 +56,9 @@ export default function MiniGameSpace({ onExit, moveCommand, startCommand, onGam
         },
       ]);
       if (error) throw error;
-  
+      console.log("[space.saveScore] done");
     } catch (e) {
-      console.error("Error saving space game score:", e);
+      console.error("Error saving space game score", e);
     }
   };
 

--- a/components/noa-eating.tsx
+++ b/components/noa-eating.tsx
@@ -37,43 +37,57 @@ export default function NoaTamagotchi() {
   // Cargar estado desde Supabase al iniciar
   useEffect(() => {
     const loadStats = async () => {
-      const { data, error } = await supabase
-        .from("noa_stats")
-        .select("*")
-        .order("updated_at", { ascending: false })
-        .limit(1);
+      try {
+        console.log('[noa-eating.loadStats]');
+        const { data, error } = await supabase
+          .from("noa_stats")
+          .select("*")
+          .order("updated_at", { ascending: false })
+          .limit(1);
 
-      if (data && data.length > 0) {
-        const latest = data[0];
-        setNoaState({
-          hunger: latest.hunger,
-          happiness: latest.happiness,
-          energy: latest.energy,
-          lastUpdated: Date.now()
-        });
-        setCoinsEarned(latest.coins_earned ?? 0);
-        setCoinsSpent(latest.coins_spent ?? 0);
+        if (error) throw error;
+
+        if (data && data.length > 0) {
+          const latest = data[0];
+          setNoaState({
+            hunger: latest.hunger,
+            happiness: latest.happiness,
+            energy: latest.energy,
+            lastUpdated: Date.now(),
+          });
+          setCoinsEarned(latest.coins_earned ?? 0);
+          setCoinsSpent(latest.coins_spent ?? 0);
+        }
+        console.log('[noa-eating.loadStats] done');
+      } catch (e) {
+        console.error('Error loading noa stats', e);
       }
     };
 
-    loadStats();
+    void loadStats();
   }, []);
 
   // Guardar estado en Supabase cada vez que cambia
   useEffect(() => {
     const saveStats = async () => {
-      await supabase.from("noa_stats").insert([
-        {
-          hunger: noaState.hunger,
-          happiness: noaState.happiness,
-          energy: noaState.energy,
-          coins_earned: coinsEarned,
-          coins_spent: coinsSpent
-        }
-      ]);
+      try {
+        console.log('[noa-eating.saveStats] saving');
+        await supabase.from("noa_stats").insert([
+          {
+            hunger: noaState.hunger,
+            happiness: noaState.happiness,
+            energy: noaState.energy,
+            coins_earned: coinsEarned,
+            coins_spent: coinsSpent,
+          },
+        ]);
+        console.log('[noa-eating.saveStats] done');
+      } catch (e) {
+        console.error('Error saving noa stats', e);
+      }
     };
 
-    saveStats();
+    void saveStats();
   }, [noaState, coinsEarned, coinsSpent]);
   return (
     <div>


### PR DESCRIPTION
## Summary
- save all tamagotchi data in Supabase instead of using localStorage
- log Supabase requests and responses and handle errors
- automatically clean old scores and stats every 30 minutes
- add logging/error handling to scoreboard and minigames
- update tests to run with vitest

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688824d2d580832586879839da2bc953